### PR TITLE
Fix experience book problem if draw is detected

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -309,11 +309,11 @@ void MainThread::search() {
                           rootPos.undo_move((*it)->move);
 
                       //Don't consider this experience move if a draw is detected
-                      if (drawDetected)
-                          continue;
-
-                      //Calculate estimated sum
-                      estimatedValue[tempExpEx] = Value(valueSum / valueWeight);
+                      if (!drawDetected)
+                      {
+                          //Calculate estimated sum
+                          estimatedValue[tempExpEx] = Value(valueSum / valueWeight);
+                      }
 
                       //Next
                       tempExpEx = tempExpEx->next;


### PR DESCRIPTION
Avoid no move situation when an experience move causes 3-fold or 50-move draw.