### PR TITLE
Avoid compiler warning

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -49,7 +49,7 @@
   INCBIN(EmbeddedNNUE, EvalFileDefaultName);
 #else
   const unsigned char        gEmbeddedNNUEData[1] = {0x0};
-  const unsigned char *const gEmbeddedNNUEEnd = &gEmbeddedNNUEData[1];
+  //const unsigned char *const gEmbeddedNNUEEnd = &gEmbeddedNNUEData[1];
   const unsigned int         gEmbeddedNNUESize = 1;
 #endif
 


### PR DESCRIPTION
Apparently, on MacOS the compiler will generate a warning about **gEmbeddedNNUEEnd** variable which is not used

This change comments the unused variable to avoid the warning